### PR TITLE
Fix persistence and add multimodal features

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,11 +15,19 @@ document.addEventListener('DOMContentLoaded', () => {
     const menuToggleButton = document.getElementById('menu-toggle-button');
     const sidebar = document.querySelector('.sidebar');
     const appTitle = document.querySelector('.app-header h1');
+    const attachFileButton = document.getElementById('attach-file-button');
+    const fileInput = document.getElementById('file-input');
+    const imagePreview = document.getElementById('image-preview');
+    const pdfNamePreview = document.getElementById('pdf-name-preview');
+    const removeAttachmentButton = document.getElementById('remove-attachment-button');
+    const attachmentPreviewArea = document.getElementById('attachment-preview-area');
 
     // --- 2. State Variables ---
     let openAIApiKey = localStorage.getItem('openai_api_key');
     let activeConversationId = null; // The ID of the chat from OUR database
     let currentResponseId = null;    // The ID from OpenAI for resuming the conversation
+    let attachedFile = null;
+    let pdfVectorStoreId = null; // used when a PDF is uploaded
 
     // --- 3. Database Setup (using Dexie.js) ---
     const db = new Dexie('LLMChatDatabase');
@@ -40,23 +48,73 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    function resetAttachmentPreview() {
+        if (attachmentPreviewArea) attachmentPreviewArea.style.display = 'none';
+        if (imagePreview) imagePreview.style.display = 'none';
+        if (pdfNamePreview) pdfNamePreview.style.display = 'none';
+        if (removeAttachmentButton) removeAttachmentButton.style.display = 'none';
+    }
+
+    function handleFileSelected(file) {
+        attachedFile = file;
+        if (!file) { resetAttachmentPreview(); return; }
+        if (attachmentPreviewArea) attachmentPreviewArea.style.display = 'block';
+        if (removeAttachmentButton) removeAttachmentButton.style.display = 'inline';
+        if (file.type.startsWith('image/')) {
+            const reader = new FileReader();
+            reader.onload = e => {
+                if (imagePreview) {
+                    imagePreview.src = e.target.result;
+                    imagePreview.style.display = 'block';
+                }
+                if (pdfNamePreview) pdfNamePreview.style.display = 'none';
+            };
+            reader.readAsDataURL(file);
+        } else if (file.type === 'application/pdf') {
+            if (pdfNamePreview) {
+                pdfNamePreview.textContent = file.name;
+                pdfNamePreview.style.display = 'block';
+            }
+            if (imagePreview) imagePreview.style.display = 'none';
+        }
+    }
+
     function addMessageToUI(sender, text, type = sender, messageId = null, isStreaming = false) {
         if (!chatMessages) return;
         let messageElement = messageId ? document.getElementById(messageId) : null;
         if (messageElement && isStreaming) {
             const paragraph = messageElement.querySelector('p');
             if (paragraph) paragraph.textContent += text;
+            chatMessages.scrollTop = chatMessages.scrollHeight;
+            return messageElement;
+        }
+
+        if (messageElement) messageElement.remove();
+        messageElement = document.createElement('div');
+        messageElement.classList.add('message', type);
+        if (messageId) messageElement.id = messageId;
+        const paragraph = document.createElement('p');
+
+        if (type === 'assistant' && !isStreaming) {
+            const safeHTML = DOMPurify.sanitize(marked.parse(text));
+            paragraph.innerHTML = safeHTML;
+            messageElement.appendChild(paragraph);
+            chatMessages.appendChild(messageElement);
+            try {
+                katex.renderMathInElement(paragraph, {
+                    delimiters: [
+                        { left: '$$', right: '$$', display: true },
+                        { left: '$', right: '$', display: false }
+                    ]
+                });
+            } catch (e) { console.warn('KaTeX render error', e); }
         } else {
-            if (messageElement) messageElement.remove();
-            messageElement = document.createElement('div');
-            messageElement.classList.add('message', type);
-            if (messageId) messageElement.id = messageId;
-            const paragraph = document.createElement('p');
             paragraph.textContent = text;
             messageElement.appendChild(paragraph);
             chatMessages.appendChild(messageElement);
         }
         chatMessages.scrollTop = chatMessages.scrollHeight;
+        return messageElement;
     }
     
     async function renderChatHistory() {
@@ -88,6 +146,7 @@ document.addEventListener('DOMContentLoaded', () => {
         
         activeConversationId = convo.id;
         currentResponseId = convo.openAIResponseId;
+        pdfVectorStoreId = convo.vectorStoreId || null;
 
         console.log(`Loaded state: activeConvo=${activeConversationId}, openAIResponseId=${currentResponseId}`);
         renderChatHistory();
@@ -100,6 +159,12 @@ document.addEventListener('DOMContentLoaded', () => {
         addMessageToUI('system', 'New chat started. Ask me anything!');
         activeConversationId = null;
         currentResponseId = null;
+        pdfVectorStoreId = null;
+        attachedFile = null;
+        if (attachmentPreviewArea) attachmentPreviewArea.style.display = 'none';
+        if (imagePreview) imagePreview.style.display = 'none';
+        if (pdfNamePreview) pdfNamePreview.style.display = 'none';
+        if (removeAttachmentButton) removeAttachmentButton.style.display = 'none';
         renderChatHistory();
         messageInput.focus();
         if (sidebar?.classList.contains('open')) sidebar.classList.remove('open');
@@ -113,7 +178,20 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
 
-        addMessageToUI('user', messageText);
+        const userBubble = addMessageToUI('user', messageText);
+        resetAttachmentPreview();
+        if (attachedFile && userBubble) {
+            if (attachedFile.type.startsWith('image/')) {
+                const img = document.createElement('img');
+                img.src = imagePreview?.src || '';
+                img.classList.add('sent-image');
+                userBubble.appendChild(img);
+            } else if (attachedFile.type === 'application/pdf') {
+                const info = document.createElement('p');
+                info.textContent = attachedFile.name;
+                userBubble.appendChild(info);
+            }
+        }
         
         const userMessage = { sender: 'user', text: messageText, type: 'user' };
         let conversationIdForThisTurn = activeConversationId;
@@ -123,6 +201,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 title: messageText.substring(0, 40) + (messageText.length > 40 ? '...' : ''),
                 messages: [userMessage],
                 openAIResponseId: null,
+                vectorStoreId: null,
                 createdAt: new Date(),
                 updatedAt: new Date(),
             };
@@ -130,10 +209,12 @@ document.addEventListener('DOMContentLoaded', () => {
             activeConversationId = conversationIdForThisTurn;
             await renderChatHistory();
         } else {
-            await db.conversations.update(conversationIdForThisTurn, {
-                'messages': Dexie.modify(msgs => msgs.push(userMessage)),
-                'updatedAt': new Date(),
-            });
+            const convo = await db.conversations.get(conversationIdForThisTurn);
+            if (convo) {
+                convo.messages.push(userMessage);
+                convo.updatedAt = new Date();
+                await db.conversations.put(convo);
+            }
         }
         
         messageInput.value = '';
@@ -143,6 +224,34 @@ document.addEventListener('DOMContentLoaded', () => {
         addMessageToUI('assistant', 'Thinking...', 'assistant-thinking', thinkingId);
 
         const requestBody = { model: modelSelector.value, instructions: "You are a helpful assistant.", stream: true, input: messageText };
+        const selectedModel = modelSelector.value;
+        const visionModels = ['gpt-4o','gpt-4o-mini','o4-mini'];
+        if (attachedFile) {
+            if (attachedFile.type.startsWith('image/')) {
+                if (!visionModels.includes(selectedModel)) {
+                    alert('Image input is only supported with vision-capable models.');
+                    sendButton.disabled = false;
+                    return;
+                }
+                const dataUrl = await new Promise(res => { const r = new FileReader(); r.onload = e => res(e.target.result); r.readAsDataURL(attachedFile); });
+                requestBody.attachments = [{ type: 'image_url', image_url: { url: dataUrl } }];
+            } else if (attachedFile.type === 'application/pdf') {
+                if (!pdfVectorStoreId) {
+                    const formData = new FormData();
+                    formData.append('file', attachedFile);
+                    const fileRes = await fetch('http://localhost:3000/api/files', { method: 'POST', body: formData });
+                    const fileData = await fileRes.json();
+                    if (!fileRes.ok) throw new Error(fileData.error || 'File upload failed');
+                    const fileId = fileData.id || fileData.file_id;
+                    const vsRes = await fetch('http://localhost:3000/api/vector_stores', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ file_ids: [fileId] }) });
+                    const vsData = await vsRes.json();
+                    if (!vsRes.ok) throw new Error(vsData.error || 'Vector store creation failed');
+                    pdfVectorStoreId = vsData.id || vsData.vector_store_id;
+                }
+                requestBody.tools = [{ type: 'file_search' }];
+                requestBody.vector_store_ids = [pdfVectorStoreId];
+            }
+        }
         if (currentResponseId) requestBody.previous_response_id = currentResponseId;
         else requestBody.store = true;
 
@@ -202,13 +311,23 @@ document.addEventListener('DOMContentLoaded', () => {
             sendButton.disabled = false;
             if (streamedResponseText) {
                 currentResponseId = newResponseIdFromServer;
-                await db.conversations.update(conversationIdForThisTurn, {
-                    'messages': Dexie.modify(msgs => msgs.push({ sender: 'assistant', text: streamedResponseText, type: 'assistant' })),
-                    'openAIResponseId': currentResponseId,
-                    'updatedAt': new Date(),
-                });
+                const convo = await db.conversations.get(conversationIdForThisTurn);
+                if (convo) {
+                    convo.messages.push({ sender: 'assistant', text: streamedResponseText, type: 'assistant' });
+                    convo.openAIResponseId = currentResponseId;
+                    if (pdfVectorStoreId) convo.vectorStoreId = pdfVectorStoreId;
+                    convo.updatedAt = new Date();
+                    await db.conversations.put(convo);
+                }
+                addMessageToUI('assistant', streamedResponseText, 'assistant', assistantMessageId, false);
                 await renderChatHistory();
             }
+            attachedFile = null;
+            pdfVectorStoreId = null;
+            if (attachmentPreviewArea) attachmentPreviewArea.style.display = 'none';
+            if (imagePreview) imagePreview.style.display = 'none';
+            if (pdfNamePreview) pdfNamePreview.style.display = 'none';
+            if (removeAttachmentButton) removeAttachmentButton.style.display = 'none';
         }
     }
 
@@ -219,6 +338,11 @@ document.addEventListener('DOMContentLoaded', () => {
         messageInput.addEventListener('keypress', (event) => { if (event.key === 'Enter' && !event.shiftKey) { event.preventDefault(); handleSendMessage(); } });
         messageInput.addEventListener('input', () => { messageInput.style.height = 'auto'; messageInput.style.height = (messageInput.scrollHeight) + 'px'; });
     }
+    if(attachFileButton && fileInput) {
+        attachFileButton.addEventListener('click', () => fileInput.click());
+        fileInput.addEventListener('change', e => handleFileSelected(e.target.files[0]));
+    }
+    if(removeAttachmentButton) removeAttachmentButton.addEventListener('click', () => { fileInput.value = ''; handleFileSelected(null); });
     if(newChatButton) newChatButton.addEventListener('click', startNewChat);
     if(menuToggleButton && sidebar) menuToggleButton.addEventListener('click', () => sidebar.classList.toggle('open'));
     if (settingsButton && settingsModal && closeButton && saveApiKeyButton && apiKeyInput) {

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
 
     <!-- Dexie.js (for IndexedDB) -->
     <script src="https://unpkg.com/dexie@3/dist/dexie.js"></script>
-    
+
     <!-- PDF.js Library (already present) -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
     <script>
@@ -82,6 +82,13 @@
             pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js';
         }
     </script>
+
+    <!-- Libraries for Markdown/LaTeX rendering and sanitization -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.17.0/dist/katex.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.3/dist/purify.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/katex@0.17.0/dist/katex.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/katex@0.17.0/dist/contrib/auto-render.min.js"></script>
     
     <script src="app.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- hook up KaTeX/DOMPurify/Marked.js in `index.html`
- sanitize and format assistant messages with Markdown/LaTeX
- store assistant replies correctly and restore vector store state
- implement image and PDF upload with vision model checks
- display attached images and reset previews when sending

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6843c5f5ff388323b7f06e18554aa385